### PR TITLE
Fix MiniDatabase `createdAt` update conflict in OAuth metadata flow

### DIFF
--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -10,6 +10,19 @@ import {
  */
 export const db = MiniDatabase.fromEnv();
 
+const MINI_DB_RESERVED_FIELDS = new Set(["createdAt"]);
+
+function asUpdatableRecord(value: unknown): Record<string, unknown> {
+	if (!value || typeof value !== "object") return {};
+
+	const record = value as Record<string, unknown>;
+	return Object.fromEntries(
+		Object.entries(record).filter(
+			([key]) => !MINI_DB_RESERVED_FIELDS.has(key)
+		)
+	);
+}
+
 /**
  * Gets user data from the database.
  */
@@ -26,13 +39,10 @@ export async function getUserData(userId: string) {
  * Sets user's is_miniapp status.
  * Always true. No gating. Everyone connects.
  */
-export async function setUserMiniAppStatus(userId: string) {
+	export async function setUserMiniAppStatus(userId: string) {
 	try {
 		const existing = await db.get(userId).catch(() => null);
-		const base =
-			existing && typeof existing === "object"
-				? (existing as Record<string, unknown>)
-				: {};
+		const base = asUpdatableRecord(existing);
 		return await db.set(userId, {
 			...base,
 			userId,
@@ -84,10 +94,7 @@ export async function updateDiscordMetadata(
 	}
 
 	const existing = await db.get(userId).catch(() => null);
-	const base =
-		existing && typeof existing === "object"
-			? (existing as Record<string, unknown>)
-			: {};
+	const base = asUpdatableRecord(existing);
 
 	await db.set(userId, {
 		...base,


### PR DESCRIPTION
### Motivation
- Prevent MongoDB update errors caused by writing MiniDatabase-internal fields back into documents when calling `db.set`, which produced `MongoServerError: Updating the path 'createdAt' would create a conflict at 'createdAt'`.

### Description
- Added a `MINI_DB_RESERVED_FIELDS` allowlist and an `asUpdatableRecord` helper in `src/utils/database.ts` to strip reserved fields (currently `createdAt`) from records before updating.
- Replaced raw spreading of fetched records with `asUpdatableRecord(existing)` in `setUserMiniAppStatus` to avoid re-writing reserved fields.
- Updated `updateDiscordMetadata` to use the same sanitized `base` object before calling `db.set` so sponsor/contributor metadata updates no longer include reserved fields.

### Testing
- Ran the TypeScript build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d62ca29194833083c466995ea09e65)