### PR TITLE
Handle sponsor target lookup failures gracefully

### DIFF
--- a/src/utils/githubSponsors.ts
+++ b/src/utils/githubSponsors.ts
@@ -215,9 +215,17 @@ export async function getSponsorMatch(githubUsername: string) {
 	const targets = getSponsorTargets();
 
 	for (const target of targets) {
-		const isSponsor = await isUserSponsoringTarget(githubUsername, target);
-		if (isSponsor) {
-			return { isSponsor: true, matchedTarget: target };
+		try {
+			const isSponsor = await isUserSponsoringTarget(githubUsername, target);
+			if (isSponsor) {
+				return { isSponsor: true, matchedTarget: target };
+			}
+		} catch (error) {
+			console.warn(
+				`[githubSponsors] Sponsor check failed for target "${target}": ${
+					error instanceof Error ? error.message : String(error)
+				}`
+			);
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- Prevent a single failing GitHub sponsor lookup from aborting the overall sponsor detection flow during Discord metadata updates.  
- Avoid runtime exceptions when a configured sponsor target (for example a removed or renamed org/user) cannot be resolved by the GitHub GraphQL API.  

### Description
- In `src/utils/githubSponsors.ts` wrapped the per-target call to `isUserSponsoringTarget` inside a `try/catch` block in `getSponsorMatch`.  
- On error the code now logs a warning with the failing `target` and the error message instead of throwing.  
- The function continues checking remaining targets and still returns `{ isSponsor: true, matchedTarget }` when any target matches, or `{ isSponsor: false, matchedTarget: null }` otherwise.  

### Testing
- Ran `npx tsc --noEmit` to validate TypeScript and it completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d63064b36083309c678c926f88dff5)