### PR TITLE
Fix GitHub sponsors GraphQL query for repositoryOwner type resolution

### DIFF
--- a/src/utils/githubSponsors.ts
+++ b/src/utils/githubSponsors.ts
@@ -52,6 +52,10 @@ function getGitHubToken() {
 	return process.env.GITHUB_TOKEN?.trim() || null;
 }
 
+function isSponsorDebugEnabled() {
+	return process.env.GITHUB_SPONSOR_DEBUG?.trim().toLowerCase() === "true";
+}
+
 async function fetchSponsorPage(targetLogin: string, cursor?: string | null) {
 	const token = getGitHubToken();
 	const query = `
@@ -171,11 +175,20 @@ async function isUserSponsoringTarget(
 	targetLogin: string
 ): Promise<boolean> {
 	const normalizedUsername = githubUsername.toLowerCase();
+	const debug = isSponsorDebugEnabled();
 	let cursor: string | null = null;
 	let pageCount = 0;
 
 	while (pageCount < 20) {
 		const page = await fetchSponsorPage(targetLogin, cursor);
+		if (debug) {
+			const pageNumber = pageCount + 1;
+			console.info(
+				`[githubSponsors] Sponsors page ${pageNumber} for "${targetLogin}": ${
+					page.sponsors.length > 0 ? page.sponsors.join(", ") : "(none)"
+				}`
+			);
+		}
 		if (page.sponsors.includes(normalizedUsername)) {
 			return true;
 		}

--- a/src/utils/githubSponsors.ts
+++ b/src/utils/githubSponsors.ts
@@ -7,10 +7,16 @@ function normalizeLogin(login: string) {
 
 type SponsorsResponse = {
 	data?: {
-		repositoryOwner?: SponsorsNode;
+		repositoryOwner?: SponsorsOwner;
 	};
 	errors?: Array<{ message: string }>;
 };
+
+type SponsorsOwner = {
+	__typename?: "User" | "Organization" | string;
+	userSponsorships?: SponsorsNode;
+	organizationSponsorships?: SponsorsNode;
+} | null;
 
 type SponsorsNode = {
 	sponsorshipsAsMaintainer: {
@@ -56,23 +62,48 @@ async function fetchSponsorPage(targetLogin: string, cursor?: string | null) {
 		) {
 			repositoryOwner(login: $login) {
 				__typename
-				sponsorshipsAsMaintainer(
-					activeOnly: true
-					includePrivate: $includePrivate
-					first: 100
-					after: $cursor
-				) {
-					pageInfo {
-						hasNextPage
-						endCursor
-					}
-					nodes {
-						sponsorEntity {
-							... on User {
-								login
+				... on User {
+					userSponsorships: sponsorshipsAsMaintainer(
+						activeOnly: true
+						includePrivate: $includePrivate
+						first: 100
+						after: $cursor
+					) {
+						pageInfo {
+							hasNextPage
+							endCursor
+						}
+						nodes {
+							sponsorEntity {
+								... on User {
+									login
+								}
+								... on Organization {
+									login
+								}
 							}
-							... on Organization {
-								login
+						}
+					}
+				}
+				... on Organization {
+					organizationSponsorships: sponsorshipsAsMaintainer(
+						activeOnly: true
+						includePrivate: $includePrivate
+						first: 100
+						after: $cursor
+					) {
+						pageInfo {
+							hasNextPage
+							endCursor
+						}
+						nodes {
+							sponsorEntity {
+								... on User {
+									login
+								}
+								... on Organization {
+									login
+								}
 							}
 						}
 					}
@@ -113,7 +144,10 @@ async function fetchSponsorPage(targetLogin: string, cursor?: string | null) {
 		);
 	}
 
-	const source = payload.data?.repositoryOwner?.sponsorshipsAsMaintainer;
+	const owner = payload.data?.repositoryOwner;
+	const source = owner?.userSponsorships?.sponsorshipsAsMaintainer
+		? owner.userSponsorships.sponsorshipsAsMaintainer
+		: owner?.organizationSponsorships?.sponsorshipsAsMaintainer;
 
 	if (!source) {
 		return {


### PR DESCRIPTION
### Motivation
- Sponsor checks were failing with GraphQL errors because `sponsorshipsAsMaintainer` is not available on the `RepositoryOwner` interface and must be requested from concrete owner types.
- The original query also caused declared-but-unused variable issues for `$cursor` and `$includePrivate` when the interface did not expose the field.

### Description
- Add a `SponsorsOwner` response type that exposes aliased `userSponsorships` and `organizationSponsorships` to represent concrete `User` and `Organization` fragment results.
- Rewrite the `SponsorsByMaintainer` GraphQL query to use inline fragments (`... on User` and `... on Organization`) and alias `sponsorshipsAsMaintainer` for each concrete type so `$cursor` and `$includePrivate` are used in valid selections.
- Update result parsing to select sponsorship data from either `userSponsorships.sponsorshipsAsMaintainer` or `organizationSponsorships.sponsorshipsAsMaintainer`, preserving the existing pagination and sponsor matching behavior.

### Testing
- Ran `npx tsc --noEmit` which completed successfully.
- Ran `npm run build` which completed successfully (shows an expected `DISCORD_BOT_TOKEN` missing runtime warning in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d63f0f98088330a3e514d5784257f9)