### PR TITLE
Add force-public sponsor mode and clearer sponsor-check logs

### DIFF
--- a/src/utils/githubSponsors.ts
+++ b/src/utils/githubSponsors.ts
@@ -49,11 +49,18 @@ function getSponsorTargets(): string[] {
 }
 
 function getGitHubToken() {
+	if (shouldForcePublicSponsors()) {
+		return null;
+	}
 	return process.env.GITHUB_TOKEN?.trim() || null;
 }
 
 function isSponsorDebugEnabled() {
 	return process.env.GITHUB_SPONSOR_DEBUG?.trim().toLowerCase() === "true";
+}
+
+function shouldForcePublicSponsors() {
+	return process.env.GITHUB_SPONSOR_FORCE_PUBLIC?.trim().toLowerCase() === "true";
 }
 
 async function fetchSponsorPage(targetLogin: string, cursor?: string | null) {
@@ -152,8 +159,14 @@ async function fetchSponsorPage(targetLogin: string, cursor?: string | null) {
 	const source = owner?.userSponsorships?.sponsorshipsAsMaintainer
 		? owner.userSponsorships.sponsorshipsAsMaintainer
 		: owner?.organizationSponsorships?.sponsorshipsAsMaintainer;
+	const debug = isSponsorDebugEnabled();
 
 	if (!source) {
+		if (debug) {
+			console.info(
+				`[githubSponsors] Sponsor query returned no sponsorshipsAsMaintainer for "${targetLogin}" (owner type: ${owner?.__typename ?? "unknown"}).`
+			);
+		}
 		return {
 			hasNextPage: false,
 			endCursor: null as string | null,
@@ -231,9 +244,17 @@ export async function getDiscordGithubUsername(accessToken: string) {
 }
 
 export async function getSponsorMatch(githubUsername: string) {
-	if (!process.env.GITHUB_TOKEN?.trim()) {
+	const token = getGitHubToken();
+	if (!token) {
 		console.warn(
-			"[githubSponsors] GITHUB_TOKEN is not set; checking public sponsorships only."
+			shouldForcePublicSponsors()
+				? "[githubSponsors] GITHUB_SPONSOR_FORCE_PUBLIC=true; checking public sponsorships only."
+				: "[githubSponsors] GITHUB_TOKEN is not set; checking public sponsorships only."
+		);
+	}
+	if (isSponsorDebugEnabled()) {
+		console.info(
+			`[githubSponsors] Sponsor check mode: ${token ? "token-authenticated" : "public-only"}.`
 		);
 	}
 


### PR DESCRIPTION
### Motivation
- Logs showing `Sponsors page ... (none)` were ambiguous about whether the GraphQL call used an auth token or only returned public sponsors, making debugging and public-only testing difficult.
- There is a need to intentionally run sponsor checks in public-only mode even when a `GITHUB_TOKEN` exists so maintainers can reproduce public-visible results.

### Description
- Add `shouldForcePublicSponsors()` and respect `GITHUB_SPONSOR_FORCE_PUBLIC=true` in `getGitHubToken()` so the code can deliberately run in public-only mode (token withheld).
- Compute the token once in `getSponsorMatch()` and emit explicit info logs showing `token-authenticated` or `public-only` mode when `GITHUB_SPONSOR_DEBUG=true` is enabled.
- Add debug logging in `fetchSponsorPage()` when `sponsorshipsAsMaintainer` is missing, including the `owner.__typename` to help explain `(none)` results.
- Preserve existing pagination and sponsor-matching behavior while improving visibility into auth mode and query results.

### Testing
- Ran `npm run -s build` and the build completed successfully.
- Ran `npx tsc --noEmit` and TypeScript checks passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d651cc114c83308081d66c51bc2f56)