### PR TITLE
Fix Discord OAuth linking for non-sponsors

### DIFF
--- a/api/discord-oauth-callback.ts
+++ b/api/discord-oauth-callback.ts
@@ -168,7 +168,14 @@ const linkedRolesHandler = mini.discordOAuthCallback({
 			scope: tokens.scope,
 		});
 
-		await updateDiscordMetadata(user.id, tokens.access_token);
+		try {
+			await updateDiscordMetadata(user.id, tokens.access_token);
+		} catch (error) {
+			console.error(
+				"[discord-oauth-callback] OAuth tokens were stored, but linked-role metadata refresh failed:",
+				error
+			);
+		}
 	},
 });
 

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -113,7 +113,7 @@ export async function updateDiscordMetadata(
 
 	const metadata = {
 		platform_name: "Dungeon Blitz",
-		platform_username: githubUsername ?? null,
+		...(githubUsername ? { platform_username: githubUsername } : {}),
 		metadata: {
 			is_sponsor: sponsorMatch.isSponsor ? "1" : "0",
 			contributor: contributorMatch.isContributor ? "1" : "0",

--- a/src/utils/oauthConfig.ts
+++ b/src/utils/oauthConfig.ts
@@ -115,4 +115,22 @@ function createDiscordOAuthConfig() {
 	};
 }
 
-export const discordOAuthConfig = createDiscordOAuthConfig();
+/**
+ * MiniInteraction 0.3.x still resolves parts of its OAuth configuration from
+ * process.env. Synchronize the normalized values so the authorization page and
+ * token exchange always use the same client ID, secret, and redirect URI.
+ */
+export function applyDiscordOAuthConfigToEnvironment(
+	config: ReturnType<typeof createDiscordOAuthConfig>,
+	env: NodeJS.ProcessEnv = process.env
+) {
+	env.DISCORD_APPLICATION_ID = config.appId;
+	env.DISCORD_CLIENT_ID = config.appId;
+	env.DISCORD_CLIENT_SECRET = config.appSecret;
+	env.DISCORD_REDIRECT_URI = config.redirectUri;
+	return config;
+}
+
+export const discordOAuthConfig = applyDiscordOAuthConfigToEnvironment(
+	createDiscordOAuthConfig()
+);


### PR DESCRIPTION
## What changed

- Synchronize the normalized Discord application ID, client secret, and redirect URI back into `process.env` for MiniInteraction 0.3.x.
- Keep the OAuth link successful after tokens are stored even when sponsor or linked-role metadata refresh fails.
- Omit `platform_username` when the Discord user has no connected GitHub account instead of sending `null` to Discord.

## Root cause

The app normalized quoted credentials and Vercel redirect fallbacks in `discordOAuthConfig`, but MiniInteraction 0.3.x can still resolve OAuth settings from the raw environment during its verification/callback flow. That allowed the authorization request and token exchange to use different values, producing Discord's `400 Bad Request` at `/oauth2/token` before sponsor checks were reached.

Additionally, post-auth sponsor/metadata refresh errors bubbled out of `onAuthorize`, turning a successfully stored OAuth connection into a 500 response. Users should be linked independently of whether they are sponsors; sponsorship only controls linked-role metadata.

## Validation

- Branch is based on current `main` and is not behind it.
- Diff is limited to the OAuth callback and OAuth/metadata utilities.
- Awaiting Vercel and repository checks before squash-merging into `main`.