### PR TITLE
Fix manual sponsor role matching

### DIFF
--- a/src/utils/githubSponsorDirect.ts
+++ b/src/utils/githubSponsorDirect.ts
@@ -5,6 +5,40 @@ function normalizeLogin(login: string) {
 	return login.trim().toLowerCase();
 }
 
+const MANUAL_SPONSOR_OVERRIDES = new Set(
+	[
+		"Falcon09092004",
+		"slorex200-ai",
+		"ejmg0607-collab",
+		"elmangomero",
+		"albert190101-hue",
+		"jaomyios",
+		"btuserglobal",
+		"rogueszou",
+		"axelnassi",
+		"joxzael",
+		"sapha59-ai",
+		"monderucdere",
+		"renGoku-wq",
+		"lawly14",
+		"kebap999",
+		"darkneesglow",
+		"neodevils",
+		"butimar408",
+		"nillion0",
+		"ewaai21",
+		"etyboo",
+		"nevastuica8",
+		"mecnunnemo-pixel",
+		"andrepda51-wq",
+		"tw1xxye",
+		"prince-159",
+		"hitkill600",
+		"y3olo",
+		"Emkata-rgb",
+	].map(normalizeLogin)
+);
+
 function getSponsorTargets() {
 	const raw = process.env.GITHUB_SPONSOR_TARGETS?.trim();
 	if (!raw) return DEFAULT_TARGETS;
@@ -86,8 +120,17 @@ async function isAccountSponsoringTarget(
 
 export async function getDirectSponsorMatch(githubUsername: string) {
 	const normalizedUsername = normalizeLogin(githubUsername);
+	const targets = getSponsorTargets();
 
-	for (const targetLogin of getSponsorTargets()) {
+	if (MANUAL_SPONSOR_OVERRIDES.has(normalizedUsername)) {
+		const matchedTarget = targets[0] ?? DEFAULT_TARGETS[0];
+		console.info(
+			`[githubSponsorDirect] Matched manual sponsor override "${normalizedUsername}" on "${matchedTarget}".`
+		);
+		return { isSponsor: true, matchedTarget };
+	}
+
+	for (const targetLogin of targets) {
 		try {
 			const isSponsor = await isAccountSponsoringTarget(
 				normalizedUsername,


### PR DESCRIPTION
## What changed
- Added the existing manual sponsor overrides to the direct sponsor fallback.
- Normalized every override and the linked GitHub username before comparison.
- Returned the configured sponsor target immediately when a manual override matches.

## Root cause
`getSponsorMatch()` lowercases the linked GitHub username, while some entries in the manual sponsor list use mixed casing (for example `Falcon09092004`). The case-sensitive array lookup therefore missed those users. The subsequent direct GitHub Sponsors query also returned false because Patreon/manual supporters are not necessarily active GitHub Sponsors.

## Impact
`Falcon09092004` and the other manually listed supporters can now refresh their Discord linked-role metadata and receive `is_sponsor=1`, regardless of GitHub username casing.

## Validation
- Confirmed the branch is one commit ahead of `main` and changes only `src/utils/githubSponsorDirect.ts`.
- Type-checked the modified module with TypeScript using the repository's strict ES2022 settings and a minimal local Node environment declaration.
- Verified mixed-case inputs normalize and match the manual override set.